### PR TITLE
[fix] Update Representative to not add duplicates.

### DIFF
--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -17,8 +17,10 @@ class Representative < ApplicationRecord
         end
       end
 
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
-          title: title_temp })
+      rep_hash = { name: official.name, ocdid: ocdid_temp,
+                   title: title_temp }
+      rep ||= Representative.find_by(rep_hash)
+      rep ||= Representative.create!(rep_hash) unless rep
       reps.push(rep)
     end
 

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Tests for the representative model
+
+require 'rails_helper'
+require 'spec_helper'
+
+class MockOfficial
+  attr_accessor :name
+
+  def initialize(official_name)
+    @name = official_name
+  end
+end
+
+class MockOffice
+  attr_accessor :name, :division_id, :official_indices
+
+  def initialize(office_name, division, indices)
+    @name = office_name
+    @division_id = division
+    @official_indices = indices
+  end
+end
+
+class MockInfo
+  attr_accessor :officials, :offices
+
+  def initialize(reps, offices_list)
+    @officials = reps
+    @offices = offices_list
+  end
+end
+
+describe Representative do
+  before do
+    @a_rep = MockOfficial.new('Tim Ryan')
+    @mock_office = MockOffice.new('U.S. Representative', 'US_REP', [0])
+    @mock_info = MockInfo.new([@a_rep], [@mock_office])
+  end
+
+  it 'adds a representative' do
+    result = described_class.civic_api_to_representative_params(@mock_info)
+    expect(result[0].name).to eq 'Tim Ryan'
+  end
+
+  it 'does not add representative twice' do
+    result1 = described_class.civic_api_to_representative_params(@mock_info)
+    result2 = described_class.civic_api_to_representative_params(@mock_info)
+    expect(result1).to eq(result2)
+  end
+end


### PR DESCRIPTION
The `Representative` model would add (call `create!`) for every response it get from the API, potentially duplicating results (duplicate results, however, would not appear in `/search` ). This makes it so representatives already in the database are not added again. It will allow two representatives with the same name in the database, but not two representatives in the same office with the same name.

If merged, update the database on Heroku with drop, create, migrate and seed.